### PR TITLE
ci: prepare external fixture

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,6 +1,5 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
-name: CMake on multiple platforms
+name: CMake on Linux
 
 on:
   push:
@@ -13,36 +12,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
-      # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ ubuntu-latest ]
         build_type: [ Debug ]
-        c_compiler: [ gcc, clang, cl ]
+        c_compiler: [ gcc, clang ]
         include:
-          # - os: windows-latest
-          #   c_compiler: cl
-          #   cpp_compiler: cl
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-        exclude:
-          # - os: windows-latest
-          #   c_compiler: gcc
-          # - os: windows-latest
-          #   c_compiler: clang
-          - os: ubuntu-latest
-            c_compiler: cl
 
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +36,15 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -yq build-essential clang-11 cmake libboost-all-dev libssl-dev libgtest-dev
+
+      - name: Prepare container (onnxruntime)
+        shell: bash
+        run: |
           ./.github/actions/download-onnxruntime-linux.sh
+
+      - name: Download assets(models)
+        shell: bash
+        run: |
           ./test/fixture/download-test-fixtures.sh
 
       - name: Set reusable strings

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
       - name: Prepare container (apt)
         shell: bash
         if: startsWith(matrix.os, 'debian') || startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -55,6 +55,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -yq build-essential clang-11 cmake libboost-all-dev libssl-dev libgtest-dev
           ./.github/actions/download-onnxruntime-linux.sh
+          ./test/fixture/download-test-fixtures.sh
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-> [!WARNING]
-> In development
-
 # ONNX Runtime Server
-[![Github CI](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-multi-platform.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-multi-platform.yml)
+[![Github CI](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-multi-platform.yml)
 [![License](https://img.shields.io/github/license/kibae/onnxruntime-server)](https://github.com/kibae/onnxruntime-server/blob/main/LICENSE)
 
 

--- a/test/fixture/download-test-fixtures.sh
+++ b/test/fixture/download-test-fixtures.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+curl -o sample/1/model.onnx "https://kibae.blob.core.windows.net/static/model1.onnx"
+curl -o sample/2/model.onnx "https://kibae.blob.core.windows.net/static/model2.onnx"

--- a/test/fixture/download-test-fixtures.sh
+++ b/test/fixture/download-test-fixtures.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")" || exit
+
 curl -o sample/1/model.onnx "https://kibae.blob.core.windows.net/static/model1.onnx"
 curl -o sample/2/model.onnx "https://kibae.blob.core.windows.net/static/model2.onnx"

--- a/test/fixture/sample/1/README.md
+++ b/test/fixture/sample/1/README.md
@@ -1,3 +1,4 @@
 # Sample model 1
 
 - test/sample-onnx-generator/sample-model1.py
+- https://drive.google.com/file/d/13Oe3NhMZ8iLAWNHcMBsZeaQKYGoU9n8F/view?usp=sharing

--- a/test/fixture/sample/1/README.md
+++ b/test/fixture/sample/1/README.md
@@ -1,4 +1,4 @@
 # Sample model 1
 
 - test/sample-onnx-generator/sample-model1.py
-- https://drive.google.com/file/d/13Oe3NhMZ8iLAWNHcMBsZeaQKYGoU9n8F/view?usp=sharing
+- https://kibae.blob.core.windows.net/static/model1.onnx

--- a/test/fixture/sample/1/model.onnx
+++ b/test/fixture/sample/1/model.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84fa83900e013fc38d46c7a1655d2a935c0ead568a70985a4bbc9e52a7141cc6
-size 7423

--- a/test/fixture/sample/2/README.md
+++ b/test/fixture/sample/2/README.md
@@ -2,4 +2,4 @@
 
 - https://huggingface.co/alimazhar-110/website_classification
 - test/sample-onnx-generator/website_classification.py
-- https://drive.google.com/file/d/1qXrTNaxu1wKf9lPdPuTEm5lgxInCDsoy/view?usp=sharing
+- https://kibae.blob.core.windows.net/static/model2.onnx

--- a/test/fixture/sample/2/README.md
+++ b/test/fixture/sample/2/README.md
@@ -2,3 +2,4 @@
 
 - https://huggingface.co/alimazhar-110/website_classification
 - test/sample-onnx-generator/website_classification.py
+- https://drive.google.com/file/d/1qXrTNaxu1wKf9lPdPuTEm5lgxInCDsoy/view?usp=sharing

--- a/test/fixture/sample/2/model.onnx
+++ b/test/fixture/sample/2/model.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73490d4be4859bd16869191cfa6b343a53e5b4a4c7d5cd3185bebc039df91db2
-size 268002610


### PR DESCRIPTION
- Remove the model fixture from the repository and download it externally if necessary.