### PR TITLE
Fix: inputs fed in wrong order causing null tensor outputsFix: iterate inputs in session-defined order to prevent null outputs

### DIFF
--- a/src/onnx/execution/context.cpp
+++ b/src/onnx/execution/context.cpp
@@ -76,8 +76,9 @@ std::vector<Ort::Value> Orts::onnx::execution::context::run() {
 	std::vector<Ort::Value> input_values;
 	input_values.reserve(inputs.size());
 
-	for (auto &input : inputs) {
-		input_values.emplace_back(std::move(input.second->tensors));
+	// Fix: iterate in session-defined order, not map alphabetical order
+	for (auto &input_info : session->inputs()) {
+		input_values.emplace_back(std::move(inputs[input_info.name]->tensors));
 	}
 
 	return this->session->run(memory_info, input_values);


### PR DESCRIPTION
Fixes #90

## Problem
When executing a session, inputs were being collected from a 
std::map which iterates in alphabetical key order, not the 
order the model expects.

For example, a model with inputs defined as:
- input_ids
- attention_mask  
- token_type_ids

Would receive them in alphabetical order instead:
- attention_mask
- input_ids
- token_type_ids

This caused the model to receive wrong data in each slot,
producing an output of all null values despite the inference
itself succeeding with a 200 response.

## Fix
Changed the input collection loop in `context::run()` to 
iterate using `session->inputs()` instead of the map, 
preserving the session-defined input order.

## Files Changed
- `src/onnx/execution/context.cpp`