### PR TITLE
ci: release 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ONNX Runtime Server
 
-[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.25.1&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
+[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.26.0&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
 [![CMake on Linux](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml)
 [![CMake on MacOS](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml)
 [![CMake on Windows](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml)
@@ -177,17 +177,17 @@ sudo cmake --install build --prefix /usr/local/onnxruntime-server
 
 - Docker hub: [kibaes/onnxruntime-server](https://hub.docker.com/r/kibaes/onnxruntime-server)
     - [
-      `1.25.1-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
+      `1.26.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
       amd64(CUDA 13.x, cuDNN 9.x)
     - [
-      `1.25.1-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
+      `1.26.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
       amd64(CUDA 12.x, cuDNN 9.x)
     - [
-      `1.25.1-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
+      `1.26.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
       amd64, arm64
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12 or 1.25.1-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12 or 1.26.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 

--- a/deploy/build-docker/README.md
+++ b/deploy/build-docker/README.md
@@ -2,7 +2,7 @@
 
 ## x64 with CUDA
 
-- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.25.1(latest) supports CUDA 12/13, cuDNN 9.
+- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.26.0(latest) supports CUDA 12/13, cuDNN 9.
 - Two CUDA variants are available:
     - `linux-cuda13`: Built on `nvidia/cuda:13.1.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:13.1.1-cudnn-runtime-ubuntu24.04`
     - `linux-cuda12`: Built on `nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`

--- a/deploy/build-docker/VERSION
+++ b/deploy/build-docker/VERSION
@@ -1,2 +1,2 @@
-export VERSION=1.25.1
+export VERSION=1.26.0
 export IMAGE_PREFIX=kibaes/onnxruntime-server

--- a/deploy/build-docker/docker-compose.yaml
+++ b/deploy/build-docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -29,7 +29,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation will be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/deploy/build-docker/linux-cpu.dockerfile
+++ b/deploy/build-docker/linux-cpu.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest AS builder
+FROM ubuntu:24.04 AS builder
 
 RUN apt update && apt install -y curl wget git build-essential cmake pkg-config libboost-all-dev libssl-dev
 RUN mkdir -p /app/source
@@ -21,7 +21,7 @@ RUN cmake --build build --parallel 8 --target onnxruntime_server_standalone
 RUN cmake --install build --prefix /app/onnxruntime-server
 
 # target
-FROM ubuntu:latest AS target
+FROM ubuntu:24.04 AS target
 COPY --from=builder /app/onnxruntime-server /app
 COPY --from=builder /usr/local/onnxruntime /usr/local/onnxruntime
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,9 +5,9 @@
 
 # Supported tags and respective Dockerfile links
 
-- [`1.25.1-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
-- [`1.25.1-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
-- [`1.25.1-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
+- [`1.26.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
+- [`1.26.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
+- [`1.26.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
 
 # How to use this image
 
@@ -29,7 +29,7 @@
     - API documentation will be available at http://localhost/api-docs.
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12 or 1.25.1-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12 or 1.26.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 
@@ -70,7 +70,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -102,7 +102,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation wl be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.25.1-linux-cuda13 # or 1.25.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ONNX Runtime Server
   description: |-
-  version: 1.25.1
+  version: 1.26.0
 externalDocs:
   description: ONNX Runtime Server
   url: https://github.com/kibae/onnxruntime-server

--- a/src/test/test_lib_version.cpp
+++ b/src/test/test_lib_version.cpp
@@ -6,5 +6,5 @@
 #include "./test_common.hpp"
 
 TEST(test_lib_version, LibVersion) {
-	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.25.1");
+	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.26.0");
 }


### PR DESCRIPTION
## Summary

- Sync onnxruntime-server with upstream ONNX Runtime 1.26.0.
- Bumps version strings via deploy/update-version.sh 1.25.1 -> 1.26.0.

## Test plan

- [x] cmake build (Debug) and ctest pass against onnxruntime 1.26.0 GPU binary.
- [x] Docker images built and pushed: linux-cpu, linux-cuda12, linux-cuda13.
- [x] Update Docker Hub repository description after merge: https://hub.docker.com/repository/docker/kibaes/onnxruntime-server/general