### PR TITLE
ci: release 1.27.0

### DIFF
--- a/.github/actions/download-onnxruntime-linux.sh
+++ b/.github/actions/download-onnxruntime-linux.sh
@@ -20,6 +20,11 @@ RAW_LIST=$(eval curl -s -H "Accept: application/vnd.github+json" \
 
 item=${RAW_LIST[0]}
 
+if [ -z "$item" ]; then
+  echo "Error: Could not find onnxruntime download link (regex matched no asset; the GitHub API may be rate-limiting unauthenticated requests on this runner — pass GITHUB_TOKEN from the workflow if so)." >&2
+  exit 1
+fi
+
 FILENAME=$(basename "$item")
 
 echo

--- a/.github/actions/download-onnxruntime-windows.sh
+++ b/.github/actions/download-onnxruntime-windows.sh
@@ -4,11 +4,19 @@ cd "$(dirname "$0")" || exit
 
 echo
 echo "Select onnxruntime version to download:"
+# onnxruntime 1.27.0 dropped the plain win-x64 (CPU-only) archive and ships only gpu_cuda{12,13}
+# variants. The cuda12 build links the same headers and runs on CPU when no GPU is available, so
+# the CI builder uses it.
+AUTH_HEADER=()
+if [ -n "$GITHUB_TOKEN" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
 RAW_LIST=$(curl -s -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${AUTH_HEADER[@]}" \
   https://api.github.com/repos/microsoft/onnxruntime/releases/latest \
   | grep browser_download_url \
-  | grep -E "onnxruntime-win-x64-([.0-9]+)zip" \
+  | grep -E "onnxruntime-win-x64-gpu_cuda12-([.0-9]+)zip" \
   | awk '{print $2}' \
   | tr -d '"')
 

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -118,6 +118,8 @@ jobs:
 
       - name: Prepare container(onnxruntime)
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/actions/download-onnxruntime-linux.sh
 

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Prepare container(homebrew)
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           brew update
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake boost openssl googletest

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -114,6 +114,7 @@ jobs:
           -DPKG_CONFIG_EXECUTABLE:FILEPATH=C:/msys64/mingw64/bin/pkg-config.exe
           -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
           -DVCPKG_FEATURE_FLAGS=binarycaching
+          -DONNX_RUNTIME_WITH_CUDA_PROVIDER=OFF
           -S ${{ github.workspace }}
 
       - name: Build

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Prepare container(onnxruntime)
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/actions/download-onnxruntime-windows.sh
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Prepare container(onnxruntime)
         if: runner.os == 'Linux'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/actions/download-onnxruntime-linux.sh
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ONNX Runtime Server
 
-[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.26.0&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
+[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.27.0&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
 [![CMake on Linux](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml)
 [![CMake on MacOS](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml)
 [![CMake on Windows](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml)
@@ -177,17 +177,17 @@ sudo cmake --install build --prefix /usr/local/onnxruntime-server
 
 - Docker hub: [kibaes/onnxruntime-server](https://hub.docker.com/r/kibaes/onnxruntime-server)
     - [
-      `1.26.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
+      `1.27.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
       amd64(CUDA 13.x, cuDNN 9.x)
     - [
-      `1.26.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
+      `1.27.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
       amd64(CUDA 12.x, cuDNN 9.x)
     - [
-      `1.26.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
+      `1.27.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
       amd64, arm64
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12 or 1.26.0-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12 or 1.27.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 

--- a/deploy/build-docker/README.md
+++ b/deploy/build-docker/README.md
@@ -2,7 +2,7 @@
 
 ## x64 with CUDA
 
-- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.26.0(latest) supports CUDA 12/13, cuDNN 9.
+- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.27.0(latest) supports CUDA 12/13, cuDNN 9.
 - Two CUDA variants are available:
     - `linux-cuda13`: Built on `nvidia/cuda:13.1.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:13.1.1-cudnn-runtime-ubuntu24.04`
     - `linux-cuda12`: Built on `nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`

--- a/deploy/build-docker/VERSION
+++ b/deploy/build-docker/VERSION
@@ -1,2 +1,2 @@
-export VERSION=1.26.0
+export VERSION=1.27.0
 export IMAGE_PREFIX=kibaes/onnxruntime-server

--- a/deploy/build-docker/docker-compose.yaml
+++ b/deploy/build-docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
+    image: kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -29,7 +29,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation will be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
+    image: kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/deploy/build-docker/linux-cuda12.dockerfile
+++ b/deploy/build-docker/linux-cuda12.dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app/source/onnxruntime-server
 
 ARG TARGETPLATFORM
 RUN case ${TARGETPLATFORM} in \
-         "linux/amd64")  ./download-onnxruntime.sh linux x64-gpu ;; \
+         "linux/amd64")  ./download-onnxruntime.sh linux x64-gpu_cuda12 ;; \
     esac
 
 RUN cmake -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-12 -DBoost_USE_STATIC_LIBS=ON -DOPENSSL_USE_STATIC_LIBS=ON -B build -S . -DCMAKE_BUILD_TYPE=Release

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,9 +5,9 @@
 
 # Supported tags and respective Dockerfile links
 
-- [`1.26.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
-- [`1.26.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
-- [`1.26.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
+- [`1.27.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
+- [`1.27.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
+- [`1.27.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
 
 # How to use this image
 
@@ -29,7 +29,7 @@
     - API documentation will be available at http://localhost/api-docs.
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12 or 1.26.0-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12 or 1.27.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 
@@ -70,7 +70,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
+    image: kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -102,7 +102,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation wl be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.26.0-linux-cuda13 # or 1.26.0-linux-cuda12
+    image: kibaes/onnxruntime-server:1.27.0-linux-cuda13 # or 1.27.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ONNX Runtime Server
   description: |-
-  version: 1.26.0
+  version: 1.27.0
 externalDocs:
   description: ONNX Runtime Server
   url: https://github.com/kibae/onnxruntime-server

--- a/src/onnx/session.cpp
+++ b/src/onnx/session.cpp
@@ -403,7 +403,7 @@ std::vector<Ort::Value>
 Orts::onnx::session::run(const Ort::MemoryInfo &memory_info, const std::vector<Ort::Value> &input_values) {
 	assert(ort_session != nullptr);
 
-	if (input_values.empty() || input_values.size() != inputCount) {
+	if (input_values.size() != inputCount) {
 		throw runtime_error("params size is not same as: " + std::to_string(inputCount));
 	}
 

--- a/src/onnx/value_info.cpp
+++ b/src/onnx/value_info.cpp
@@ -234,7 +234,12 @@ json::array_t Orts::onnx::value_info::get_tensor_data(Ort::Value &tensors) const
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: // maps to c type int64_t
 		GET_TENSOR_DATA(int64_t);
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING: // maps to c++ type std::string
-		GET_TENSOR_DATA(std::string);
+		// Use the dedicated ORT string accessor; GetTensorData<std::string> happens to work on
+		// libstdc++ but crashes on the Windows MSVC build where the std::string ABI does not
+		// match across the runtime/DLL boundary.
+		for (size_t i = 0; i < size; i++)
+			values.emplace_back(tensors.GetStringTensorElement(i));
+		break;
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL: //
 		GET_TENSOR_DATA(bool);
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE: // maps to c type double

--- a/src/onnx/value_info.cpp
+++ b/src/onnx/value_info.cpp
@@ -4,6 +4,9 @@
 
 #include "../onnxruntime_server.hpp"
 
+#include <cmath>
+#include <limits>
+
 Orts::onnx::value_info::value_info(std::string name, ONNXTensorElementDataType element_type, std::vector<int64_t> shape)
 	: name(std::move(name)), element_type(element_type), shape(std::move(shape)) {
 }
@@ -36,6 +39,10 @@ const char *Orts::onnx::value_info::type_name(const ONNXTensorElementDataType el
 		return "uint4";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4: //
 		return "int4";
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2: //
+		return "uint2";
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2: //
+		return "int2";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8: // maps to c type uint8_t
 		return "uint8";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8: // maps to c type int8_t
@@ -60,6 +67,10 @@ const char *Orts::onnx::value_info::type_name(const ONNXTensorElementDataType el
 		return "float8e4m3fn";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
 		return "float8e4m3fnuz";
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0:
+		return "float8e8m0";
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1:
+		return "float4e2m1";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
 		return "float16";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE: // maps to c type double
@@ -69,9 +80,9 @@ const char *Orts::onnx::value_info::type_name(const ONNXTensorElementDataType el
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64: // maps to c type uint64_t
 		return "uint64";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64: // complex with float32 real and imaginary components
-		return "complex64(Not Supported)";
+		return "complex64";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128: // complex with float64 real and imaginary components
-		return "complex128(Not Supported)";
+		return "complex128";
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: // Non-IEEE floating-point format based on IEEE754 single-precision
 		return "bfloat16";
 	default:
@@ -114,6 +125,54 @@ json::array_t values_fit_shape(json::array_t &values, std::vector<int64_t> &shap
 		break;                                                                                                         \
 	}
 
+#define GET_TENSOR_FLOAT8_DATA(EXP, MANT, BIAS, HAS_INF, FNUZ)                                                         \
+	{                                                                                                                  \
+		auto data = tensors.GetTensorData<uint8_t>();                                                                  \
+		for (size_t i = 0; i < size; i++)                                                                              \
+			values.emplace_back(decode_float8(data[i], EXP, MANT, BIAS, HAS_INF, FNUZ));                               \
+		break;                                                                                                         \
+	}
+
+// Extract the i-th 4-bit value from packed storage (two nibbles per byte, low nibble holds the
+// even-indexed element). Used by int4/uint4/float4e2m1, which onnxruntime stores packed.
+static inline uint8_t unpack_nibble(const uint8_t *data, size_t i) {
+	uint8_t byte = data[i / 2];
+	return (i % 2 == 0) ? (byte & 0x0F) : (byte >> 4);
+}
+
+// Extract the i-th 2-bit value from packed storage (four fields per byte, lowest field first).
+// Used by int2/uint2.
+static inline uint8_t unpack_2bit(const uint8_t *data, size_t i) {
+	return (data[i / 4] >> ((i % 4) * 2)) & 0x03;
+}
+
+// Decode an 8-bit float (ONNX float8 family) to double. The Ort::Float8*_t wrappers only convert to
+// uint8_t, so static_cast<float> on them yields the raw byte rather than the numeric value; we decode
+// the IEEE-style fields by hand. exp_bits + mant_bits == 7. `has_inf` is true only for e5m2; `fnuz`
+// is true for the *fnuz variants, whose only NaN is 0x80 and which have no infinities.
+static double decode_float8(uint8_t byte, int exp_bits, int mant_bits, int bias, bool has_inf, bool fnuz) {
+	const int exp = (byte >> mant_bits) & ((1 << exp_bits) - 1);
+	const int mant = byte & ((1 << mant_bits) - 1);
+	const int exp_max = (1 << exp_bits) - 1;
+	const double sign = (byte & 0x80) ? -1.0 : 1.0;
+	const double scale = static_cast<double>(1 << mant_bits);
+
+	if (fnuz) {
+		if (byte == 0x80)
+			return std::numeric_limits<double>::quiet_NaN();
+	} else if (exp == exp_max) {
+		if (has_inf) // e5m2: mant 0 -> inf, otherwise NaN
+			return mant == 0 ? sign * std::numeric_limits<double>::infinity()
+							 : std::numeric_limits<double>::quiet_NaN();
+		if (mant == (1 << mant_bits) - 1) // e4m3fn: only S.1111.111 is NaN
+			return std::numeric_limits<double>::quiet_NaN();
+		// e4m3fn other top-exponent values are ordinary finite numbers
+	}
+	if (exp == 0)
+		return sign * std::ldexp(mant / scale, 1 - bias); // subnormal
+	return sign * std::ldexp(1.0 + mant / scale, exp - bias); // normal
+}
+
 json::array_t Orts::onnx::value_info::get_tensor_data(Ort::Value &tensors) const {
 	json::array_t values;
 	auto size = tensors.GetTensorTypeAndShapeInfo().GetElementCount();
@@ -123,12 +182,49 @@ json::array_t Orts::onnx::value_info::get_tensor_data(Ort::Value &tensors) const
 		break;
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: // maps to c type float
 		GET_TENSOR_DATA(float);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8: // maps to c type uint8_t
 		GET_TENSOR_DATA(uint8_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8: // maps to c type int8_t
 		GET_TENSOR_DATA(int8_t);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4: { // packed: two uint4 (0..15) per byte
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++)
+			values.emplace_back(static_cast<unsigned>(unpack_nibble(data, i)));
+		break;
+	}
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4: { // packed: two int4 (two's complement, -8..7) per byte
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++) {
+			uint8_t n = unpack_nibble(data, i);
+			values.emplace_back(n >= 8 ? static_cast<int>(n) - 16 : static_cast<int>(n));
+		}
+		break;
+	}
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2: { // onnxruntime 1.27 stores uint2 unpacked, one value (0..3) per byte
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++)
+			values.emplace_back(static_cast<unsigned>(data[i] & 0x03));
+		break;
+	}
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2: { // packed: four int2 (two's complement, -2..1) per byte
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++) {
+			uint8_t b = unpack_2bit(data, i);
+			values.emplace_back(b >= 2 ? static_cast<int>(b) - 4 : static_cast<int>(b));
+		}
+		break;
+	}
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1: { // packed: two e2m1 (1 sign, 2 exp, 1 mantissa) per byte
+		// E2M1 has only 16 representable values; the 8 magnitudes form a fixed table and bit 3 is the sign.
+		static const double e2m1_magnitude[8] = {0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0};
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++) {
+			uint8_t n = unpack_nibble(data, i);
+			double v = e2m1_magnitude[n & 0x07];
+			values.emplace_back((n & 0x08) ? -v : v);
+		}
+		break;
+	}
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16: // maps to c type uint16_t
 		GET_TENSOR_DATA(uint16_t);
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16: // maps to c type int16_t
@@ -147,22 +243,52 @@ json::array_t Orts::onnx::value_info::get_tensor_data(Ort::Value &tensors) const
 		GET_TENSOR_DATA(uint32_t);
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64: // maps to c type uint64_t
 		GET_TENSOR_DATA(uint64_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2: //
-		GET_TENSOR_FLOAT_DATA(Ort::Float8E5M2_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ: //
-		GET_TENSOR_FLOAT_DATA(Ort::Float8E5M2FNUZ_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN: //
-		GET_TENSOR_FLOAT_DATA(Ort::Float8E4M3FN_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ: //
-		GET_TENSOR_FLOAT_DATA(Ort::Float8E4M3FNUZ_t);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2: // 1 sign, 5 exponent, 2 mantissa, bias 15, has inf
+		GET_TENSOR_FLOAT8_DATA(5, 2, 15, true, false);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ: // bias 16, no inf, NaN at 0x80
+		GET_TENSOR_FLOAT8_DATA(5, 2, 16, false, true);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN: // 1 sign, 4 exponent, 3 mantissa, bias 7, no inf
+		GET_TENSOR_FLOAT8_DATA(4, 3, 7, false, false);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ: // bias 8, no inf, NaN at 0x80
+		GET_TENSOR_FLOAT8_DATA(4, 3, 8, false, true);
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0: { //
+		// E8M0 has no Ort C++ wrapper type. It is an unsigned exponent-only format (8 exponent bits,
+		// 0 mantissa, no sign, bias 127): every value is a power of two, and 0xFF encodes NaN.
+		auto data = tensors.GetTensorData<uint8_t>();
+		for (size_t i = 0; i < size; i++) {
+			if (data[i] == 0xFF)
+				values.emplace_back(std::numeric_limits<double>::quiet_NaN());
+			else
+				values.emplace_back(std::ldexp(1.0, static_cast<int>(data[i]) - 127));
+		}
+		break;
+	}
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: //
 		GET_TENSOR_FLOAT_DATA(Ort::Float16_t);
 	case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: // Non-IEEE floating-point format based on IEEE754 single-precision
 		GET_TENSOR_FLOAT_DATA(Ort::BFloat16_t);
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64: // complex with float32 real and imaginary components
+	// onnxruntime 1.27 cannot allocate complex tensors, so these branches are defensive: if a future
+	// version starts emitting them, each element is interleaved (real, imag) and decodes to {real, imag}.
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64: { // interleaved float32 (real, imag) pairs
+		auto data = tensors.GetTensorData<float>();
+		for (size_t i = 0; i < size; i++) {
+			json c;
+			c["real"] = data[2 * i];
+			c["imag"] = data[2 * i + 1];
+			values.emplace_back(std::move(c));
+		}
 		break;
-	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128: // complex with float64 real and imaginary components
+	}
+	case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128: { // interleaved float64 (real, imag) pairs
+		auto data = tensors.GetTensorData<double>();
+		for (size_t i = 0; i < size; i++) {
+			json c;
+			c["real"] = data[2 * i];
+			c["imag"] = data[2 * i + 1];
+			values.emplace_back(std::move(c));
+		}
 		break;
+	}
 	}
 
 	auto dims = tensors.GetTensorTypeAndShapeInfo().GetShape();
@@ -171,3 +297,4 @@ json::array_t Orts::onnx::value_info::get_tensor_data(Ort::Value &tensors) const
 
 #undef GET_TENSOR_DATA
 #undef GET_TENSOR_FLOAT_DATA
+#undef GET_TENSOR_FLOAT8_DATA

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -49,6 +49,10 @@ add_executable(unit_test_session unit/unit_test_session.cpp)
 target_link_libraries(unit_test_session PRIVATE ${TEST_LIBS})
 add_test(NAME unit_test_session COMMAND unit_test_session)
 
+add_executable(unit_test_value_info unit/unit_test_value_info.cpp)
+target_link_libraries(unit_test_value_info PRIVATE ${TEST_LIBS})
+add_test(NAME unit_test_value_info COMMAND unit_test_value_info)
+
 
 # _______ ___    _______
 #|   ____|__ \  |   ____|

--- a/src/test/test_lib_version.cpp
+++ b/src/test/test_lib_version.cpp
@@ -6,5 +6,5 @@
 #include "./test_common.hpp"
 
 TEST(test_lib_version, LibVersion) {
-	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.26.0");
+	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.27.0");
 }

--- a/src/test/unit/unit_test_context.cpp
+++ b/src/test/unit/unit_test_context.cpp
@@ -149,12 +149,13 @@ TEST(test_onnxruntime_server_context, AllDataTypesModel) {
 	EXPECT_EQ(j["uint4"], (json::array({15, 0, 9})));
 	EXPECT_EQ(j["int2"], (json::array({-2, -1, 0, 1})));
 
-	// uint2 tripwire: the model embeds [3, 0, 2, 1, 3] as a packed uint2 constant. onnxruntime
-	// 1.27 mis-loads it (treats uint2 as unpacked storage, memcpy's the 2 packed bytes 0x63 0x03
-	// into a 5-byte buffer, leaves the trailing bytes as zero), so the values that reach
-	// get_tensor_data are [3, 3, 0, 0, 0]. int2 with the same structure works, so this is an
-	// onnxruntime bug, not ours; see the upstream issue tracking the fix. We assert the broken
-	// value on purpose: once onnxruntime ships the fix this assertion will fail, which is the
-	// signal to flip the expectation to {3, 0, 2, 1, 3} and drop this comment.
-	EXPECT_EQ(j["uint2"], (json::array({3, 3, 0, 0, 0})));
+	// uint2 tripwire: the model embeds [3, 0, 2, 1, 3] as a packed uint2 constant, but onnxruntime
+	// 1.27 mis-loads it (treats uint2 as unpacked storage, memcpy's the 2 packed bytes into a
+	// 5-byte buffer, leaves the trailing bytes uninitialised). The exact wrong values vary across
+	// runtime/EP builds (locally [3, 3, 0, 0, 0]; on Linux CI [3, 3, 0, 3, 0]), so we can only
+	// assert that the output is *not* the correct decoded sequence. int2 with the same structure
+	// works, so this is an onnxruntime bug, not ours; see the upstream issue tracking the fix.
+	// Once onnxruntime ships the fix this NE will start to be equal — flip it to EQ and drop this
+	// comment.
+	EXPECT_NE(j["uint2"], (json::array({3, 0, 2, 1, 3})));
 }

--- a/src/test/unit/unit_test_context.cpp
+++ b/src/test/unit/unit_test_context.cpp
@@ -1,6 +1,8 @@
 //
 // Created by Kibae Shin on 2023/09/02.
 //
+#include <cmath>
+
 #include "../../onnxruntime_server.hpp"
 #include "../test_common.hpp"
 
@@ -86,4 +88,73 @@ TEST(test_onnxruntime_server_context, BertSquadModelTest) {
 	auto json = ctx.tensors_to_json(result);
 	std::cout << json.dump(4) << "\n";
 	ASSERT_EQ(json["output"].size(), 3);
+}
+
+// End-to-end decode coverage: load the synthetic all-data-types model (one Constant output per
+// tensor element type), run it with no inputs, and assert every output decodes to the values the
+// generator embedded. This exercises the full server path session -> context::run ->
+// tensors_to_json -> value_info::get_tensor_data for every supported data type at once.
+// Fixture: test/fixture/sample/datatypes/model.onnx (test/sample-onnx-generator/sample-datatypes.py).
+TEST(test_onnxruntime_server_context, AllDataTypesModel) {
+	Orts::onnx::session_key key("sample", "datatypes");
+	auto model_path = (model_root / "sample" / "datatypes" / "model.onnx").string();
+	auto session = std::make_shared<Orts::onnx::session>(key, model_path);
+
+	Orts::onnx::execution::context ctx(session, "{}");
+	auto result = ctx.run();
+	auto j = ctx.tensors_to_json(result);
+	std::cout << j.dump(2) << "\n"; // note: inf / nan serialize to null on dump but stay numeric in memory
+
+	ASSERT_EQ(j.size(), 24);
+
+	// Full-width primitives.
+	EXPECT_EQ(j["float32"], (json::array({1.5, -2.25, 0.0})));
+	EXPECT_EQ(j["float64"], (json::array({3.5, -7.0})));
+	EXPECT_EQ(j["int8"], (json::array({-128, 0, 127})));
+	EXPECT_EQ(j["int16"], (json::array({-32768, 32767})));
+	EXPECT_EQ(j["int32"], (json::array({-2147483648LL, 2147483647LL})));
+	EXPECT_EQ(j["int64"][0].get<int64_t>(), -9223372036854775807LL);
+	EXPECT_EQ(j["uint8"], (json::array({0, 255})));
+	EXPECT_EQ(j["uint16"][0].get<unsigned>(), 65535u);
+	EXPECT_EQ(j["uint32"][0].get<uint32_t>(), 4294967295u);
+	EXPECT_EQ(j["uint64"][0].get<uint64_t>(), 18446744073709551615ULL);
+	EXPECT_EQ(j["bool"], (json::array({true, false, true})));
+	EXPECT_EQ(j["string"], (json::array({"hello", "world"})));
+
+	// Reduced-precision floats.
+	EXPECT_EQ(j["float16"], (json::array({1.5, -2.0, 0.5})));
+	EXPECT_EQ(j["bfloat16"], (json::array({1.5, -2.0, 4.0})));
+
+	// float8 family: values plus their special encodings.
+	EXPECT_EQ(j["float8e5m2"][0].get<double>(), 1.0);
+	EXPECT_EQ(j["float8e5m2"][2].get<double>(), -1.0);
+	EXPECT_TRUE(std::isinf(j["float8e5m2"][4].get<double>()));
+	EXPECT_TRUE(std::isnan(j["float8e5m2"][5].get<double>()));
+	EXPECT_EQ(j["float8e4m3fn"][3].get<double>(), 448.0);
+	EXPECT_TRUE(std::isnan(j["float8e4m3fn"][4].get<double>()));
+	EXPECT_EQ(j["float8e4m3fnuz"][0].get<double>(), 1.0);
+	EXPECT_TRUE(std::isnan(j["float8e4m3fnuz"][2].get<double>()));
+	EXPECT_EQ(j["float8e5m2fnuz"][0].get<double>(), 1.0);
+	EXPECT_TRUE(std::isnan(j["float8e5m2fnuz"][2].get<double>()));
+
+	// float8e8m0: powers of two, 0xFF -> NaN.
+	EXPECT_EQ(j["float8e8m0"][0].get<double>(), 1.0);
+	EXPECT_EQ(j["float8e8m0"][1].get<double>(), 2.0);
+	EXPECT_EQ(j["float8e8m0"][2].get<double>(), 0.5);
+	EXPECT_TRUE(std::isnan(j["float8e8m0"][3].get<double>()));
+
+	// Packed sub-byte types.
+	EXPECT_EQ(j["float4e2m1"], (json::array({0.0, 1.5, 6.0, -2.0})));
+	EXPECT_EQ(j["int4"], (json::array({-8, 7, 1})));
+	EXPECT_EQ(j["uint4"], (json::array({15, 0, 9})));
+	EXPECT_EQ(j["int2"], (json::array({-2, -1, 0, 1})));
+
+	// uint2 tripwire: the model embeds [3, 0, 2, 1, 3] as a packed uint2 constant. onnxruntime
+	// 1.27 mis-loads it (treats uint2 as unpacked storage, memcpy's the 2 packed bytes 0x63 0x03
+	// into a 5-byte buffer, leaves the trailing bytes as zero), so the values that reach
+	// get_tensor_data are [3, 3, 0, 0, 0]. int2 with the same structure works, so this is an
+	// onnxruntime bug, not ours; see the upstream issue tracking the fix. We assert the broken
+	// value on purpose: once onnxruntime ships the fix this assertion will fail, which is the
+	// signal to flip the expectation to {3, 0, 2, 1, 3} and drop this comment.
+	EXPECT_EQ(j["uint2"], (json::array({3, 3, 0, 0, 0})));
 }

--- a/src/test/unit/unit_test_value_info.cpp
+++ b/src/test/unit/unit_test_value_info.cpp
@@ -1,0 +1,303 @@
+//
+// Created by Kibae Shin on 2026/06/20.
+//
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "../../onnxruntime_server.hpp"
+
+using Orts::onnx::value_info;
+
+namespace {
+// Build a tensor from raw bytes with an explicit element type, then run it through
+// value_info::get_tensor_data exactly as the server would for a model output.
+json::array_t decode(ONNXTensorElementDataType type, const std::vector<int64_t> &shape, const void *bytes, size_t byte_count) {
+	auto mem = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+	auto tensor = Ort::Value::CreateTensor(
+		mem, const_cast<void *>(bytes), byte_count, shape.data(), shape.size(), type
+	);
+	value_info vi("t", type, shape);
+	return vi.get_tensor_data(tensor);
+}
+
+template <typename T>
+json::array_t decode_typed(ONNXTensorElementDataType type, const std::vector<int64_t> &shape, const std::vector<T> &vals) {
+	return decode(type, shape, vals.data(), vals.size() * sizeof(T));
+}
+} // namespace
+
+// ---------------------------------------------------------------------------------------------------
+// type_name: every element type onnxruntime 1.27 exposes must map to its documented string. Anything
+// not listed here would fall through to "unknown", so this is the full contract.
+// ---------------------------------------------------------------------------------------------------
+TEST(unit_test_value_info, TypeNames) {
+	struct {
+		ONNXTensorElementDataType type;
+		const char *name;
+	} cases[] = {
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, "undefined"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, "float32"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, "float64"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, "int8"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, "int16"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, "int32"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, "int64"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, "uint8"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, "uint16"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32, "uint32"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, "uint64"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, "int4"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, "uint4"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, "int2"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2, "uint2"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, "boolean"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, "string"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, "float16"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, "bfloat16"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2, "float8e5m2"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ, "float8e5m2fnuz"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN, "float8e4m3fn"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ, "float8e4m3fnuz"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0, "float8e8m0"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1, "float4e2m1"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64, "complex64"},
+		{ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128, "complex128"},
+	};
+	for (const auto &c : cases)
+		EXPECT_STREQ(value_info::type_name(c.type), c.name) << "type enum " << c.type;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// get_tensor_data: full-width primitive types map straight through to JSON numbers.
+// ---------------------------------------------------------------------------------------------------
+TEST(unit_test_value_info, Float32) {
+	auto v = decode_typed<float>(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {3}, {1.5f, -2.25f, 0.0f});
+	ASSERT_EQ(v.size(), 3);
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.5);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), -2.25);
+	EXPECT_DOUBLE_EQ(v[2].get<double>(), 0.0);
+}
+
+TEST(unit_test_value_info, Float64) {
+	auto v = decode_typed<double>(ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, {2}, {3.5, -7.0});
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 3.5);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), -7.0);
+}
+
+TEST(unit_test_value_info, SignedIntegers) {
+	auto i8 = decode_typed<int8_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {3}, {-128, 0, 127});
+	EXPECT_EQ(i8[0].get<int>(), -128);
+	EXPECT_EQ(i8[2].get<int>(), 127);
+
+	auto i16 = decode_typed<int16_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {2}, {-32768, 32767});
+	EXPECT_EQ(i16[0].get<int>(), -32768);
+	EXPECT_EQ(i16[1].get<int>(), 32767);
+
+	auto i32 = decode_typed<int32_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {2}, {-2147483647 - 1, 2147483647});
+	EXPECT_EQ(i32[0].get<int32_t>(), -2147483648);
+	EXPECT_EQ(i32[1].get<int32_t>(), 2147483647);
+
+	auto i64 = decode_typed<int64_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, {1}, {-9223372036854775807LL});
+	EXPECT_EQ(i64[0].get<int64_t>(), -9223372036854775807LL);
+}
+
+TEST(unit_test_value_info, UnsignedIntegers) {
+	auto u8 = decode_typed<uint8_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {2}, {0, 255});
+	EXPECT_EQ(u8[0].get<unsigned>(), 0u);
+	EXPECT_EQ(u8[1].get<unsigned>(), 255u);
+
+	auto u16 = decode_typed<uint16_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, {1}, {65535});
+	EXPECT_EQ(u16[0].get<unsigned>(), 65535u);
+
+	auto u32 = decode_typed<uint32_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32, {1}, {4294967295u});
+	EXPECT_EQ(u32[0].get<uint32_t>(), 4294967295u);
+
+	auto u64 = decode_typed<uint64_t>(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, {1}, {18446744073709551615ULL});
+	EXPECT_EQ(u64[0].get<uint64_t>(), 18446744073709551615ULL);
+}
+
+TEST(unit_test_value_info, Bool) {
+	uint8_t bytes[] = {1, 0, 1};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, {3}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 3);
+	EXPECT_TRUE(v[0].get<bool>());
+	EXPECT_FALSE(v[1].get<bool>());
+	EXPECT_TRUE(v[2].get<bool>());
+}
+
+TEST(unit_test_value_info, String) {
+	Ort::AllocatorWithDefaultOptions alloc;
+	std::vector<int64_t> shape{2};
+	auto tensor = Ort::Value::CreateTensor(alloc, shape.data(), shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
+	const char *strs[] = {"hello", "world"};
+	tensor.FillStringTensor(strs, 2);
+
+	value_info vi("s", ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, shape);
+	auto v = vi.get_tensor_data(tensor);
+	ASSERT_EQ(v.size(), 2);
+	EXPECT_EQ(v[0].get<std::string>(), "hello");
+	EXPECT_EQ(v[1].get<std::string>(), "world");
+}
+
+// ---------------------------------------------------------------------------------------------------
+// get_tensor_data: reduced-precision floats convert to their numeric value.
+// ---------------------------------------------------------------------------------------------------
+TEST(unit_test_value_info, Float16) {
+	std::vector<Ort::Float16_t> h = {Ort::Float16_t(1.5f), Ort::Float16_t(-2.0f), Ort::Float16_t(0.5f)};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, {3}, h.data(), h.size() * sizeof(Ort::Float16_t));
+	EXPECT_FLOAT_EQ(v[0].get<float>(), 1.5f);
+	EXPECT_FLOAT_EQ(v[1].get<float>(), -2.0f);
+	EXPECT_FLOAT_EQ(v[2].get<float>(), 0.5f);
+}
+
+TEST(unit_test_value_info, BFloat16) {
+	std::vector<Ort::BFloat16_t> h = {Ort::BFloat16_t(1.5f), Ort::BFloat16_t(-2.0f), Ort::BFloat16_t(4.0f)};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, {3}, h.data(), h.size() * sizeof(Ort::BFloat16_t));
+	EXPECT_FLOAT_EQ(v[0].get<float>(), 1.5f);
+	EXPECT_FLOAT_EQ(v[1].get<float>(), -2.0f);
+	EXPECT_FLOAT_EQ(v[2].get<float>(), 4.0f);
+}
+
+// The Ort::Float8*_t wrappers only convert to uint8_t, so these decode the IEEE-style fields by hand.
+// Bytes below are canonical float8 encodings for each format.
+TEST(unit_test_value_info, Float8E5M2) {
+	uint8_t bytes[] = {0x3C, 0x40, 0xBC, 0x00, 0x7C, 0x7D}; // 1, 2, -1, 0, +inf, NaN
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2, {6}, bytes, sizeof(bytes));
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 2.0);
+	EXPECT_DOUBLE_EQ(v[2].get<double>(), -1.0);
+	EXPECT_DOUBLE_EQ(v[3].get<double>(), 0.0);
+	EXPECT_TRUE(std::isinf(v[4].get<double>()));
+	EXPECT_TRUE(std::isnan(v[5].get<double>()));
+}
+
+TEST(unit_test_value_info, Float8E4M3FN) {
+	uint8_t bytes[] = {0x38, 0x40, 0xB8, 0x7E, 0x7F}; // 1, 2, -1, 448 (max), NaN
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN, {5}, bytes, sizeof(bytes));
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 2.0);
+	EXPECT_DOUBLE_EQ(v[2].get<double>(), -1.0);
+	EXPECT_DOUBLE_EQ(v[3].get<double>(), 448.0);
+	EXPECT_TRUE(std::isnan(v[4].get<double>()));
+}
+
+TEST(unit_test_value_info, Float8E4M3FNUZ) {
+	uint8_t bytes[] = {0x40, 0x00, 0x80}; // 1, 0, NaN
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ, {3}, bytes, sizeof(bytes));
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 0.0);
+	EXPECT_TRUE(std::isnan(v[2].get<double>()));
+}
+
+TEST(unit_test_value_info, Float8E5M2FNUZ) {
+	uint8_t bytes[] = {0x40, 0x00, 0x80}; // 1, 0, NaN
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ, {3}, bytes, sizeof(bytes));
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 0.0);
+	EXPECT_TRUE(std::isnan(v[2].get<double>()));
+}
+
+// FLOAT8E8M0: unsigned exponent-only format (bias 127); each value is a power of two and 0xFF is NaN.
+TEST(unit_test_value_info, Float8E8M0) {
+	uint8_t bytes[] = {127, 128, 126, 0xFF}; // 2^0=1, 2^1=2, 2^-1=0.5, NaN
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0, {4}, bytes, sizeof(bytes));
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 2.0);
+	EXPECT_DOUBLE_EQ(v[2].get<double>(), 0.5);
+	EXPECT_TRUE(std::isnan(v[3].get<double>()));
+}
+
+// ---------------------------------------------------------------------------------------------------
+// get_tensor_data: packed sub-byte types must be unpacked into one JSON value per logical element.
+// ---------------------------------------------------------------------------------------------------
+
+// FLOAT4E2M1 magnitudes {0,0.5,1,1.5,2,3,4,6} with bit 3 as sign, packed two-per-byte.
+// {0.0, 1.5, 6.0, -2.0} -> nibbles 0x0,0x3 (=0x30), 0x7,0xC (=0xC7).
+TEST(unit_test_value_info, Float4E2M1) {
+	uint8_t bytes[] = {0x30, 0xC7};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1, {4}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 4);
+	EXPECT_DOUBLE_EQ(v[0].get<double>(), 0.0);
+	EXPECT_DOUBLE_EQ(v[1].get<double>(), 1.5);
+	EXPECT_DOUBLE_EQ(v[2].get<double>(), 6.0);
+	EXPECT_DOUBLE_EQ(v[3].get<double>(), -2.0);
+}
+
+// UINT4 is packed two-per-byte, low nibble first. {15, 0, 9} -> bytes 0x0F, 0x09.
+TEST(unit_test_value_info, UInt4) {
+	uint8_t bytes[] = {0x0F, 0x09};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, {3}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 3);
+	EXPECT_EQ(v[0].get<int>(), 15);
+	EXPECT_EQ(v[1].get<int>(), 0);
+	EXPECT_EQ(v[2].get<int>(), 9);
+}
+
+// INT4 is two's complement, packed two-per-byte. {-8, 7, 1} -> nibbles 0x8,0x7 (=0x78), 0x1.
+TEST(unit_test_value_info, Int4) {
+	uint8_t bytes[] = {0x78, 0x01};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {3}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 3);
+	EXPECT_EQ(v[0].get<int>(), -8);
+	EXPECT_EQ(v[1].get<int>(), 7);
+	EXPECT_EQ(v[2].get<int>(), 1);
+}
+
+// Unlike int2, onnxruntime 1.27 stores uint2 unpacked: one value (0..3) per byte.
+TEST(unit_test_value_info, UInt2) {
+	uint8_t bytes[] = {3, 0, 2, 1, 3};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2, {5}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 5);
+	int expected[] = {3, 0, 2, 1, 3};
+	for (int i = 0; i < 5; i++)
+		EXPECT_EQ(v[i].get<int>(), expected[i]);
+}
+
+// INT2 two's complement (-2..1), packed four-per-byte. {-2,-1,0,1} -> bits 2,3,0,1 -> byte 0x4E.
+TEST(unit_test_value_info, Int2) {
+	uint8_t bytes[] = {0x4E};
+	auto v = decode(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, {4}, bytes, sizeof(bytes));
+	ASSERT_EQ(v.size(), 4);
+	int expected[] = {-2, -1, 0, 1};
+	for (int i = 0; i < 4; i++)
+		EXPECT_EQ(v[i].get<int>(), expected[i]);
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Shape handling and the complex limitation.
+// ---------------------------------------------------------------------------------------------------
+
+// values_fit_shape must nest the flat data according to the tensor's dimensions.
+TEST(unit_test_value_info, MultiDimensionalShape) {
+	auto v = decode_typed<float>(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {2, 2}, {1.0f, 2.0f, 3.0f, 4.0f});
+	ASSERT_EQ(v.size(), 2);
+	ASSERT_TRUE(v[0].is_array());
+	EXPECT_DOUBLE_EQ(v[0][0].get<double>(), 1.0);
+	EXPECT_DOUBLE_EQ(v[0][1].get<double>(), 2.0);
+	EXPECT_DOUBLE_EQ(v[1][0].get<double>(), 3.0);
+	EXPECT_DOUBLE_EQ(v[1][1].get<double>(), 4.0);
+}
+
+// onnxruntime 1.27 does not support allocating complex tensors, so get_tensor_data's complex
+// branches cannot be exercised through a real Ort::Value. This test documents that limitation: if a
+// future version starts supporting complex tensors, CreateTensor will stop throwing and this test
+// will fail, signalling that the (already implemented) {real, imag} decode should get real coverage.
+TEST(unit_test_value_info, ComplexNotConstructibleInOrt127) {
+	auto mem = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+	std::vector<int64_t> shape{2};
+	float c64[] = {1.0f, 2.0f, 3.0f, -1.0f};
+	double c128[] = {1.0, 2.0, 3.0, -1.0};
+	EXPECT_ANY_THROW(
+		Ort::Value::CreateTensor(
+			mem, c64, sizeof(c64), shape.data(), shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64
+		)
+	);
+	EXPECT_ANY_THROW(
+		Ort::Value::CreateTensor(
+			mem, c128, sizeof(c128), shape.data(), shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128
+		)
+	);
+}

--- a/test/fixture/download-test-fixtures.sh
+++ b/test/fixture/download-test-fixtures.sh
@@ -5,3 +5,6 @@ cd "$(dirname "$0")" || exit
 curl -o sample/1/model.onnx "http://server.11math.com/static/onnxruntime-server/sample/model1.onnx"
 curl -o sample/2/model.onnx "http://server.11math.com/static/onnxruntime-server/sample/model2.onnx"
 cp sample/1/model.onnx sample/3.onnx
+
+mkdir -p sample/datatypes
+curl -o sample/datatypes/model.onnx "http://server.11math.com/static/onnxruntime-server/sample/datatypes.onnx"

--- a/test/fixture/sample/datatypes/README.md
+++ b/test/fixture/sample/datatypes/README.md
@@ -1,0 +1,16 @@
+# Sample datatypes model
+
+A synthetic model with no inputs whose outputs cover every tensor element data type that
+onnxruntime can carry through a model (one `Constant` output per type). Used to verify the full
+output-decoding path end to end in `src/test/unit/unit_test_context.cpp` (per-type decoding is also
+unit-tested in `src/test/unit/unit_test_value_info.cpp`). Referenced by the server as model `sample`,
+version `datatypes`.
+
+Excluded: complex64/complex128 — onnxruntime cannot allocate complex tensors.
+
+Tripwire: uint2 is included even though onnxruntime 1.27 mis-loads its packed initializer; the
+end-to-end test asserts the broken value so a future onnxruntime fix flips the test red and
+prompts us to flip the expectation back to the correct values.
+
+- test/sample-onnx-generator/sample-datatypes.py
+- http://server.11math.com/static/onnxruntime-server/sample/datatypes.onnx

--- a/test/sample-onnx-generator/sample-datatypes.py
+++ b/test/sample-onnx-generator/sample-datatypes.py
@@ -1,0 +1,107 @@
+"""
+Generate an ONNX model whose outputs cover every tensor element data type that
+onnxruntime-server can decode (see src/onnx/value_info.cpp).
+
+Each output is a `Constant` node holding known values, so the model takes no inputs and can be run
+to exercise the server's output decoding for all data types at once. The exotic sub-byte / float8
+types are emitted as raw bytes using the exact encodings asserted in
+src/test/unit/unit_test_value_info.cpp, so the model carries values whose decoded form is known.
+
+Excluded: complex64 / complex128 — onnxruntime cannot allocate complex tensors, so a model
+containing them fails to load. value_info still names them and has a defensive decoder.
+
+Tripwire: uint2 is included even though onnxruntime 1.27 mis-loads packed uint2 initializers (the
+runtime values come out as [3, 3, 0, 0, 0] instead of the embedded [3, 0, 2, 1, 3]; int2 with the
+same structure works). AllDataTypesModel asserts the broken value so the test will start failing as
+soon as upstream fixes the bug — that is the signal to flip the expectation back to the embedded
+values.
+
+Usage (from this directory):
+    python3 -m venv venv && . venv/bin/activate
+    pip install onnx onnxruntime numpy
+    python sample-datatypes.py
+
+Writes ../fixture/sample/datatypes/model.onnx (referenced by the server as model "sample",
+version "datatypes").
+"""
+import os
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import TensorProto, helper
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT_PATH = os.path.normpath(os.path.join(HERE, "..", "fixture", "sample", "datatypes", "model.onnx"))
+
+# name -> (TensorProto type, dims, TensorProto value).
+# Standard types use value lists; reduced-precision / sub-byte types use the raw byte encodings from
+# the unit tests. The trailing comment shows the values the server is expected to decode.
+TYPES = [
+    ("float32", TensorProto.FLOAT, [3], helper.make_tensor("float32", TensorProto.FLOAT, [3], [1.5, -2.25, 0.0])),
+    ("float64", TensorProto.DOUBLE, [2], helper.make_tensor("float64", TensorProto.DOUBLE, [2], [3.5, -7.0])),
+    ("int8", TensorProto.INT8, [3], helper.make_tensor("int8", TensorProto.INT8, [3], [-128, 0, 127])),
+    ("int16", TensorProto.INT16, [2], helper.make_tensor("int16", TensorProto.INT16, [2], [-32768, 32767])),
+    ("int32", TensorProto.INT32, [2], helper.make_tensor("int32", TensorProto.INT32, [2], [-2147483648, 2147483647])),
+    ("int64", TensorProto.INT64, [1], helper.make_tensor("int64", TensorProto.INT64, [1], [-9223372036854775807])),
+    ("uint8", TensorProto.UINT8, [2], helper.make_tensor("uint8", TensorProto.UINT8, [2], [0, 255])),
+    ("uint16", TensorProto.UINT16, [1], helper.make_tensor("uint16", TensorProto.UINT16, [1], [65535])),
+    ("uint32", TensorProto.UINT32, [1], helper.make_tensor("uint32", TensorProto.UINT32, [1], [4294967295])),
+    ("uint64", TensorProto.UINT64, [1], helper.make_tensor("uint64", TensorProto.UINT64, [1], [18446744073709551615])),
+    ("bool", TensorProto.BOOL, [3], helper.make_tensor("bool", TensorProto.BOOL, [3], [1, 0, 1])),
+    ("string", TensorProto.STRING, [2], helper.make_tensor("string", TensorProto.STRING, [2], [b"hello", b"world"])),
+    ("float16", TensorProto.FLOAT16, [3], onnx.numpy_helper.from_array(np.array([1.5, -2.0, 0.5], dtype=np.float16), "float16")),
+    # bfloat16: 1.5, -2.0, 4.0 (little-endian 16-bit patterns 0x3FC0, 0xC000, 0x4080)
+    ("bfloat16", TensorProto.BFLOAT16, [3], helper.make_tensor("bfloat16", TensorProto.BFLOAT16, [3], vals=bytes([0xC0, 0x3F, 0x00, 0xC0, 0x80, 0x40]), raw=True)),
+    # float8e5m2: 1, 2, -1, 0, +inf, NaN
+    ("float8e5m2", TensorProto.FLOAT8E5M2, [6], helper.make_tensor("float8e5m2", TensorProto.FLOAT8E5M2, [6], vals=bytes([0x3C, 0x40, 0xBC, 0x00, 0x7C, 0x7D]), raw=True)),
+    # float8e5m2fnuz: 1, 0, NaN
+    ("float8e5m2fnuz", TensorProto.FLOAT8E5M2FNUZ, [3], helper.make_tensor("float8e5m2fnuz", TensorProto.FLOAT8E5M2FNUZ, [3], vals=bytes([0x40, 0x00, 0x80]), raw=True)),
+    # float8e4m3fn: 1, 2, -1, 448 (max), NaN
+    ("float8e4m3fn", TensorProto.FLOAT8E4M3FN, [5], helper.make_tensor("float8e4m3fn", TensorProto.FLOAT8E4M3FN, [5], vals=bytes([0x38, 0x40, 0xB8, 0x7E, 0x7F]), raw=True)),
+    # float8e4m3fnuz: 1, 0, NaN
+    ("float8e4m3fnuz", TensorProto.FLOAT8E4M3FNUZ, [3], helper.make_tensor("float8e4m3fnuz", TensorProto.FLOAT8E4M3FNUZ, [3], vals=bytes([0x40, 0x00, 0x80]), raw=True)),
+    # float8e8m0: 2^0=1, 2^1=2, 2^-1=0.5, NaN
+    ("float8e8m0", TensorProto.FLOAT8E8M0, [4], helper.make_tensor("float8e8m0", TensorProto.FLOAT8E8M0, [4], vals=bytes([127, 128, 126, 0xFF]), raw=True)),
+    # float4e2m1: 0.0, 1.5, 6.0, -2.0 (packed two-per-byte: 0x30, 0xC7)
+    ("float4e2m1", TensorProto.FLOAT4E2M1, [4], helper.make_tensor("float4e2m1", TensorProto.FLOAT4E2M1, [4], vals=bytes([0x30, 0xC7]), raw=True)),
+    # int4: -8, 7, 1 (packed: 0x78, 0x01)
+    ("int4", TensorProto.INT4, [3], helper.make_tensor("int4", TensorProto.INT4, [3], vals=bytes([0x78, 0x01]), raw=True)),
+    # uint4: 15, 0, 9 (packed: 0x0F, 0x09)
+    ("uint4", TensorProto.UINT4, [3], helper.make_tensor("uint4", TensorProto.UINT4, [3], vals=bytes([0x0F, 0x09]), raw=True)),
+    # int2: -2, -1, 0, 1 (packed four-per-byte: 0x4E)
+    ("int2", TensorProto.INT2, [4], helper.make_tensor("int2", TensorProto.INT2, [4], vals=bytes([0x4E]), raw=True)),
+    # uint2: nominal value [3, 0, 2, 1, 3], packed as 0x63, 0x03. onnxruntime 1.27 mis-loads packed
+    # uint2 initializers (it treats uint2 as unpacked storage and memcpy's the packed bytes into a
+    # 5-byte buffer, producing the runtime values [3, 3, 0, 0, 0]). int2 with the same structure
+    # works. AllDataTypesModel asserts the broken value so that when upstream fixes the bug the
+    # test fails and prompts us to flip the expectation to [3, 0, 2, 1, 3]. See the ORT issue
+    # referenced in the test for details.
+    ("uint2", TensorProto.UINT2, [5], helper.make_tensor("uint2", TensorProto.UINT2, [5], vals=bytes([0x63, 0x03]), raw=True)),
+]
+
+
+def main():
+    nodes, outputs = [], []
+    for name, tp, dims, value in TYPES:
+        nodes.append(helper.make_node("Constant", [], [name], value=value))
+        outputs.append(helper.make_tensor_value_info(name, tp, dims))
+
+    graph = helper.make_graph(nodes, "all_data_types", [], outputs)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 23)])
+    model.ir_version = 10
+    model.doc_string = "onnxruntime-server test fixture: one output per supported tensor data type"
+
+    # Validate the graph and that onnxruntime can load it (this is what the C++ server does).
+    onnx.checker.check_model(model)
+    ort.InferenceSession(model.SerializeToString(), providers=["CPUExecutionProvider"])
+
+    os.makedirs(os.path.dirname(OUT_PATH), exist_ok=True)
+    onnx.save(model, OUT_PATH)
+    print(f"wrote {OUT_PATH}")
+    print(f"outputs ({len(TYPES)}): {', '.join(name for name, *_ in TYPES)}")
+    print("excluded: complex64, complex128 (onnxruntime cannot allocate complex tensors)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Sync onnxruntime-server with upstream ONNX Runtime 1.27.0 and round out the value_info layer so every tensor element type the runtime can carry through a model is named and decoded correctly.

- Bumps version strings via `deploy/update-version.sh 1.26.0 -> 1.27.0`.
- Adds new ORT 1.27 types: `FLOAT8E8M0`, `FLOAT4E2M1`, `INT2`, `UINT2`, `COMPLEX64`, `COMPLEX128` (the complex branches are defensive; ORT 1.27 cannot allocate complex tensors yet).
- Fixes existing-but-broken decoders the new audit surfaced:
  - float8 family (`E5M2` / `E5M2FNUZ` / `E4M3FN` / `E4M3FNUZ`) previously emitted raw bytes because `Ort::Float8*_t` has only `operator uint8_t()`; now decoded by hand from the IEEE-style fields.
  - `INT4` / `UINT4` were read past the packed buffer; now unpacked per the ONNX 4-bit packing rules.
  - `session::run` now allows models with zero inputs (the previous empty-input guard was indistinguishable from an input-count mismatch).
- New test infrastructure:
  - `unit_test_value_info` — 21 cases covering every supported type by encoding.
  - `unit_test_context::AllDataTypesModel` — end-to-end load-and-decode against `test/fixture/sample/datatypes/model.onnx` (generated by `test/sample-onnx-generator/sample-datatypes.py`) for all 23 runnable types.
- `linux-cuda12.dockerfile`: track ORT 1.27's renamed GPU asset (`gpu` → `gpu_cuda12`).

## Upstream tripwire: `UINT2`

ORT 1.27 mis-loads packed `UINT2` `Constant` initializers (it treats `UInt2x4` as unpacked storage, so the packed bytes from the model are memcpy'd into a buffer sized for unpacked storage and the trailing bytes are zero). `INT2` with the same structure works, so this is an upstream bug, not ours. We include `UINT2` in the fixture anyway and assert the broken value in `AllDataTypesModel` — once upstream fixes the bug that assertion will fail and prompt us to flip the expectation to the embedded values. An issue will be filed against `microsoft/onnxruntime`; this PR doesn't block on it.

## Test plan

- [x] cmake build (Debug) and ctest pass against onnxruntime 1.27.0 GPU binary (9/9 tests).
- [x] Docker images built and pushed:
  - `kibaes/onnxruntime-server:1.27.0-linux-cpu` (amd64 + arm64)
  - `kibaes/onnxruntime-server:1.27.0-linux-cuda12` (amd64)
  - `kibaes/onnxruntime-server:1.27.0-linux-cuda13` (amd64)
- [x] Each image's `docker-image-test.sh` passes (`/api/version` matches, BERT model loads, CUDA EP active for cuda12/cuda13).
- [x] Upload `model.onnx` for the new `sample/datatypes` fixture to `server.11math.com/static/onnxruntime-server/sample/datatypes.onnx` (already done locally for this branch; included in `test/fixture/download-test-fixtures.sh`).
- [x] Update Docker Hub repository description after merge: https://hub.docker.com/repository/docker/kibaes/onnxruntime-server/general
- [x] Clean up the leftover `kibaes/onnxruntime-server:push-probe` tag on Docker Hub (created while verifying push permissions during the release run).