### PR TITLE
ci: release 1.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ONNX Runtime Server
 
-[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.27.1&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
+[![ONNX Runtime](https://img.shields.io/github/v/release/microsoft/onnxruntime?filter=v1.28.0&label=ONNX%20Runtime)](https://github.com/microsoft/onnxruntime)
 [![CMake on Linux](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-linux.yml)
 [![CMake on MacOS](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-macos.yml)
 [![CMake on Windows](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml/badge.svg)](https://github.com/kibae/onnxruntime-server/actions/workflows/cmake-windows.yml)
@@ -179,17 +179,17 @@ sudo cmake --install build --prefix /usr/local/onnxruntime-server
 
 - Docker hub: [kibaes/onnxruntime-server](https://hub.docker.com/r/kibaes/onnxruntime-server)
     - [
-      `1.27.1-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
+      `1.28.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile)
       amd64(CUDA 13.x, cuDNN 9.x)
     - [
-      `1.27.1-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
+      `1.28.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile)
       amd64(CUDA 12.x, cuDNN 9.x)
     - [
-      `1.27.1-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
+      `1.28.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile)
       amd64, arm64
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12 or 1.27.1-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12 or 1.28.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 

--- a/deploy/build-docker/README.md
+++ b/deploy/build-docker/README.md
@@ -2,7 +2,7 @@
 
 ## x64 with CUDA
 
-- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.27.1(latest) supports CUDA 12/13, cuDNN 9.
+- [ONNX Runtime Binary](https://github.com/microsoft/onnxruntime/releases) v1.28.0(latest) supports CUDA 12/13, cuDNN 9.
 - Two CUDA variants are available:
     - `linux-cuda13`: Built on `nvidia/cuda:13.1.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:13.1.1-cudnn-runtime-ubuntu24.04`
     - `linux-cuda12`: Built on `nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04`, runtime based on `nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`

--- a/deploy/build-docker/VERSION
+++ b/deploy/build-docker/VERSION
@@ -1,2 +1,2 @@
-export VERSION=1.27.1
+export VERSION=1.28.0
 export IMAGE_PREFIX=kibaes/onnxruntime-server

--- a/deploy/build-docker/docker-compose.yaml
+++ b/deploy/build-docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -29,7 +29,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation will be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/deploy/build-docker/download-onnxruntime.sh
+++ b/deploy/build-docker/download-onnxruntime.sh
@@ -5,11 +5,13 @@ cd "$(dirname "$0")" || exit
 OS=$1
 ARCH=$2
 
+RELEASE=$(curl -s -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/microsoft/onnxruntime/releases/latest)
+
 echo
 echo "Select onnxruntime version to download:"
-RAW_LIST=$(curl -s -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/microsoft/onnxruntime/releases/latest \
+RAW_LIST=$(echo "$RELEASE" \
   | grep browser_download_url \
   | grep -E "onnxruntime-${OS}-${ARCH}-([.0-9]+)tgz" \
   | awk '{print $2}' \
@@ -18,20 +20,58 @@ RAW_LIST=$(curl -s -H "Accept: application/vnd.github+json" \
 
 item=${RAW_LIST[0]}
 
-FILENAME=$(basename "$item")
-
-echo
-echo "Downloading $item"
-echo
-
-wget -q "$item"
-
 mkdir -p /usr/local/onnxruntime
-tar vzxf "$FILENAME" -C /usr/local/onnxruntime --strip-components=1
+
+if [ -n "$item" ]; then
+  FILENAME=$(basename "$item")
+
+  echo
+  echo "Downloading $item"
+  echo
+
+  wget -q "$item" || exit 1
+  tar vzxf "$FILENAME" -C /usr/local/onnxruntime --strip-components=1 || exit 1
+  rm -f "$FILENAME"
+elif [ "${OS}-${ARCH}" = "linux-aarch64" ]; then
+  # onnxruntime 1.28.0 uploaded the SBOM folder as onnxruntime-linux-aarch64.zip in place of the
+  # onnxruntime-linux-aarch64-<version>.tgz its own manifest lists, so the release carries no
+  # usable aarch64 archive. The Microsoft.ML.OnnxRuntime nupkg ships that same CPU build under
+  # runtimes/linux-arm64 with an identical header set, so fall back to it until the release asset
+  # is fixed. The tgz branch above takes over again as soon as it reappears.
+  VERSION=$(echo "$RELEASE" | grep -m 1 '"tag_name"' | awk -F'"' '{print $4}' | sed 's/^v//')
+  if [ -z "$VERSION" ]; then
+    echo "Error: could not resolve the onnxruntime release version for the aarch64 fallback." >&2
+    exit 1
+  fi
+
+  NUPKG="microsoft.ml.onnxruntime.${VERSION}.nupkg"
+
+  echo
+  echo "Downloading $NUPKG (no aarch64 archive in release v${VERSION})"
+  echo
+
+  wget -q -O "$NUPKG" \
+    "https://api.nuget.org/v3-flatcontainer/microsoft.ml.onnxruntime/${VERSION}/${NUPKG}" || exit 1
+  unzip -q -o "$NUPKG" 'runtimes/linux-arm64/native/*' 'build/native/include/*' -d nupkg || exit 1
+
+  mkdir -p /usr/local/onnxruntime/lib /usr/local/onnxruntime/include
+  cp nupkg/runtimes/linux-arm64/native/*.so /usr/local/onnxruntime/lib/ || exit 1
+  cp nupkg/build/native/include/* /usr/local/onnxruntime/include/ || exit 1
+
+  # The nupkg ships the library flat as libonnxruntime.so, but its SONAME is libonnxruntime.so.1,
+  # which is what the loader will look for at runtime. The tgz layout carries that link already;
+  # create it here rather than leaving it to the builder-stage ldconfig, because the target stage
+  # only copies this directory and never runs ldconfig itself.
+  ln -sf libonnxruntime.so /usr/local/onnxruntime/lib/libonnxruntime.so.1 || exit 1
+
+  rm -rf "$NUPKG" nupkg
+else
+  echo "Error: no onnxruntime archive matched onnxruntime-${OS}-${ARCH}-<version>.tgz." >&2
+  exit 1
+fi
+
 sh -c 'echo "/usr/local/onnxruntime/lib" > /etc/ld.so.conf.d/onnxruntime.conf'
 ldconfig
-
-rm -f "$FILENAME"
 
 echo
 echo "Done"

--- a/deploy/build-docker/linux-cpu.dockerfile
+++ b/deploy/build-docker/linux-cpu.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04 AS builder
 
-RUN apt update && apt install -y curl wget git build-essential cmake pkg-config libboost-all-dev libssl-dev
+RUN apt update && apt install -y curl wget unzip git build-essential cmake pkg-config libboost-all-dev libssl-dev
 RUN mkdir -p /app/source
 
 WORKDIR /app/source

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,9 +5,9 @@
 
 # Supported tags and respective Dockerfile links
 
-- [`1.27.1-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
-- [`1.27.1-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
-- [`1.27.1-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
+- [`1.28.0-linux-cuda13`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda13.dockerfile) amd64(CUDA 13.x, cuDNN 9.x)
+- [`1.28.0-linux-cuda12`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cuda12.dockerfile) amd64(CUDA 12.x, cuDNN 9.x)
+- [`1.28.0-linux-cpu`](https://github.com/kibae/onnxruntime-server/blob/main/deploy/build-docker/linux-cpu.dockerfile) amd64, arm64
 
 # How to use this image
 
@@ -29,7 +29,7 @@
     - API documentation will be available at http://localhost/api-docs.
 
 ```shell
-DOCKER_IMAGE=kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12 or 1.27.1-linux-cpu
+DOCKER_IMAGE=kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12 or 1.28.0-linux-cpu
 
 docker pull ${DOCKER_IMAGE}
 
@@ -70,7 +70,7 @@ services:
   onnxruntime_server_simple:
     # After the docker container is up, you can use the REST API (http://localhost:8080).
     # API documentation will be available at http://localhost:8080/api-docs.
-    image: kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12
     ports:
       - "8080:80" # for http backend
     volumes:
@@ -102,7 +102,7 @@ services:
   onnxruntime_server_advanced:
     # After the docker container is up, you can use the REST API (http://localhost, https://localhost).
     # API documentation wl be available at http://localhost/api-docs.
-    image: kibaes/onnxruntime-server:1.27.1-linux-cuda13 # or 1.27.1-linux-cuda12
+    image: kibaes/onnxruntime-server:1.28.0-linux-cuda13 # or 1.28.0-linux-cuda12
     ports:
       - "80:80" # for http backend
       - "443:443" # for https backend

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ONNX Runtime Server
   description: |-
-  version: 1.27.1
+  version: 1.28.0
 externalDocs:
   description: ONNX Runtime Server
   url: https://github.com/kibae/onnxruntime-server

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -421,7 +421,7 @@ components:
           nullable: false
         graph_optimization_level:
           type: string
-          enum: [disable, basic, extended, all]
+          enum: [disable, basic, extended, layout, all]
           nullable: false
         enable_cpu_mem_arena:
           type: boolean

--- a/src/onnx/session.cpp
+++ b/src/onnx/session.cpp
@@ -47,6 +47,8 @@ GraphOptimizationLevel parse_graph_opt_level(const std::string &v, bool &valid) 
 		return ORT_ENABLE_BASIC;
 	if (v == "extended")
 		return ORT_ENABLE_EXTENDED;
+	if (v == "layout")
+		return ORT_ENABLE_LAYOUT;
 	if (v == "all")
 		return ORT_ENABLE_ALL;
 	valid = false;

--- a/src/test/test_lib_version.cpp
+++ b/src/test/test_lib_version.cpp
@@ -6,5 +6,5 @@
 #include "./test_common.hpp"
 
 TEST(test_lib_version, LibVersion) {
-	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.27.1");
+	EXPECT_EQ(onnxruntime_server::onnx::version(), "1.28.0");
 }

--- a/src/test/unit/unit_test_session.cpp
+++ b/src/test/unit/unit_test_session.cpp
@@ -84,6 +84,24 @@ TEST(unit_test_session, SessionWithSessionOptions) {
 	ASSERT_EQ(so["config_entries"]["session.disable_prepacking"], "1");
 }
 
+// ORT_ENABLE_LAYOUT sits between ORT_ENABLE_EXTENDED and ORT_ENABLE_ALL in
+// GraphOptimizationLevel, so "layout" has to map to it rather than fall through to the invalid
+// branch that would drop graph_optimization_level from the echo.
+TEST(unit_test_session, SessionOptionsGraphOptimizationLevelLayout) {
+	Orts::onnx::session_key key("sample", "1");
+	auto session = std::make_shared<Orts::onnx::session>(
+		key, model1_path.string(),
+		R"({
+			"session_options": {
+				"graph_optimization_level": "layout"
+			}
+		})"_json
+	);
+	auto j = session->to_json();
+	ASSERT_TRUE(j["option"].contains("session_options"));
+	ASSERT_EQ(j["option"]["session_options"]["graph_optimization_level"], "layout");
+}
+
 // Type-mismatched values (e.g. string for an int field), enum strings outside our mapping, and
 // keys we do not pass to ORT at all must be silently dropped from the echo. Sibling entries that
 // pass our shape check and our enum mapping are still applied and echoed. Note that ORT's own


### PR DESCRIPTION
## Summary

- Sync onnxruntime-server with upstream ONNX Runtime 1.28.0.
- Bumps version strings via deploy/update-version.sh 1.27.1 -> 1.28.0.
- Accepts `"layout"` for `session_options.graph_optimization_level`, so `ORT_ENABLE_LAYOUT` is reachable.
- Sources the linux/arm64 runtime from the NuGet package, because upstream's 1.28.0 aarch64 release asset is broken.

## Upstream 1.28.0 review

Checked the 1.28.0 release notes and diffed the 1.27.1 vs 1.28.0 headers for anything the server has to handle:

- **Tensor element data types** — `ONNXTensorElementDataType` is unchanged from 1.27.1. No new packed/sub-byte type to unpack; `value_info.cpp` already covers the full enum.
- **`OrtErrorCode`** — moved to a new `onnxruntime_error_code.h` and gained `ORT_DEVICE_RESET`. The server never inspects `OrtErrorCode` (it only catches `Ort::Exception`), so nothing to wire up. Recovering a cached session after a device reset would be a separate feature.
- **Session options** — 1.28.0 adds string config keys that mirror setters the server already exposes as typed fields (`session.intra_op_num_threads`, `session.execution_mode`, `session.graph_optimization_level`, …) plus `session.name_based_layer_assignment`. All are already reachable through the existing generic `config_entries` passthrough, so no new typed fields were added.
- **`GraphOptimizationLevel`** — `parse_graph_opt_level` was missing a string for `ORT_ENABLE_LAYOUT` (a pre-existing gap, not new in 1.28.0). Added `"layout"` with a unit test and the openapi enum entry.
- **ONNX 1.22.0 / protobuf 6.33.5** — the repo pins no ONNX or opset version of its own, so there is nothing to sync.

## Broken upstream aarch64 asset

ONNX Runtime 1.28.0 does not ship a usable Linux aarch64 archive. Where 1.27.1 published a 7 MB `onnxruntime-linux-aarch64-1.27.1.tgz`, 1.28.0 publishes a 350 KB `onnxruntime-linux-aarch64.zip` that contains only `_manifest/spdx_2.2/` — no libraries, no headers, no nested archive. That SBOM's own file list names `./onnxruntime-linux-aarch64-1.28.0.tgz`, so the packaging pipeline built the right artifact and the upload step published the manifest folder in its place.

`download-onnxruntime.sh` now falls back to the `Microsoft.ML.OnnxRuntime` nupkg for linux/aarch64, which ships the same CPU build under `runtimes/linux-arm64` (verified: ELF aarch64, version string `1.28.0`, header file set identical to the official tarball). The nupkg lays the library out flat as `libonnxruntime.so` while its SONAME is `libonnxruntime.so.1`, so the script recreates that link — the target stage only copies the directory and never runs `ldconfig`. The tgz branch takes over again as soon as upstream fixes the asset.

The script also used to fall through to `wget`/`tar` on an empty filename and exit 0 when no archive matched, surfacing the failure later as a confusing cmake error; a missing archive now fails it directly.

## Test plan

- [x] cmake build (Debug) and ctest pass locally against onnxruntime 1.28.0 GPU binary (9/9).
- [x] `download-onnxruntime.sh linux x64` (tgz) and `linux aarch64` (nupkg fallback) both verified end to end into a sandboxed prefix.
- [ ] Cross-platform CI passes (Linux / Windows / macOS).
- [ ] Docker images built and pushed: linux-cpu (amd64+arm64), linux-cuda12, linux-cuda13.
- [x] Update Docker Hub repository description after merge: https://hub.docker.com/repository/docker/kibaes/onnxruntime-server/general
